### PR TITLE
Added filter for open PR

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ async function main() {
         commit_sha: sha || context.sha,
     });
 
-    const pr = result.data.length > 0 && result.data[0];
+    const pr = result.data.length > 0 && result.data.filter(el => el.state === 'open')[0];
 
     core.setOutput('pr', pr && pr.number || '');
     core.setOutput('number', pr && pr.number || '');


### PR DESCRIPTION
# Added filter for open PR

Simply just modifying the one line from:

https://github.com/jwalton/gh-find-current-pr/blob/b6f8d7342efe4913388d5d1ac7f4b956caa5db52/main.js#L15

to

```javascript
const pr = result.data.length > 0 && result.data.filter(el => el.state === 'open')[0];
```

You can see in [my test PR](https://github.com/8BitJonny/gh-find-current-pr/pull/1) that I created in my Fork and in [the actions tab](https://github.com/8BitJonny/gh-find-current-pr/actions) that it works as expected and the github action run triggered by merging the PR doesn't return any PR number anymore.

I don't know how active you still are with this repository so I would wait a bit and if I don't get a response for this PR I would switch in my company to use my Fork as a Github action. I'd love to still use yours as you are the original author of this repo and I want to give you this credit but I kinda want to switch fast to the new version since it currently makes our tests fail.

closes #2