### PR TITLE
use defaults to retrieve the github token and sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Additionally, `title` and `body` outputs are available as well to get the respec
       # Find the PR associated with this push, if there is one.
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       # This will echo "Your PR is 7", or be skipped if there is no current PR.
       - run: echo "Your PR is ${PR}"
         if: success() && steps.findPr.outputs.number

--- a/action.yml
+++ b/action.yml
@@ -3,10 +3,11 @@ author: jwalton
 description: Find a PR associated with the current commit.
 inputs:
   github-token:
-    description: The GitHub token used to create an authenticated client.
+    description: The GitHub token used to create an authenticated client.  Defaults to github provided token.
+    default: ${{ github.token }}
   sha:
     description: Sha to get PR for.  Defaults to current sha.
-    required: false
+    default: ${{ github.sha }}
 outputs:
   pr:
     description: The PR if one was found. (e.g. '345' for #345) [Deprecated: Please use number instead]

--- a/main.js
+++ b/main.js
@@ -3,13 +3,13 @@ const { GitHub, context } = require('@actions/github');
 
 async function main() {
     const token = core.getInput('github-token', { required: true });
-    const sha = core.getInput('sha');
+    const sha = core.getInput('sha', { required: true});
 
     const client = new GitHub(token, {});
     const result = await client.repos.listPullRequestsAssociatedWithCommit({
         owner: context.repo.owner,
         repo: context.repo.repo,
-        commit_sha: sha || context.sha,
+        commit_sha: sha,
     });
 
     const pr = result.data.length > 0 && result.data[0];


### PR DESCRIPTION
Use the GitHub provided `${{ github.token }}` and `${{ github.sha }}` as defaults so the user does not need to provide them (and simplify the JS).

Example of `actions/checkout` using the same [syntax](https://github.com/actions/checkout/blob/main/action.yml#L24).

*This update does **NOT** require existing users to change anything.*