### PR TITLE
fix: Upgrade to node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,30 +6,30 @@ This action tries to figure out the current PR.
 
 If the event is a `pull_request`, it's very easy to get the current PR number
 from the context via `${{ github.event.number }}`, but unfortunately this
-information does not seem to be readily available for a `push` event.  This
+information does not seem to be readily available for a `push` event. This
 action sends a request to GitHub to find the PR associated with the current SHA,
 and returns its number in the `number` output. `number` will be an empty string if there is no
 PR.
 
 Additionally, `title` and `body` outputs are available as well to get the respective title and body of the PR.
 
-By default, `gh-find-current-pr` will only return open PRs.  You can pass in a
+By default, `gh-find-current-pr` will only return open PRs. You can pass in a
 `state` parameter to pick "open", "closed", or "all" PRs.
 
 ## Usage
 
 ```yaml
-    steps:
-      - uses: actions/checkout@v4
-      # Find the PR associated with this push, if there is one.
-      - uses: jwalton/gh-find-current-pr@main
-        id: findPr
-        with:
-          # Can be "open", "closed", or "all".  Defaults to "open".
-          state: open
-      # This will echo "Your PR is 7", or be skipped if there is no current PR.
-      - run: echo "Your PR is ${PR}"
-        if: success() && steps.findPr.outputs.number
-        env:
-          PR: ${{ steps.findPr.outputs.pr }}
+steps:
+  - uses: actions/checkout@v4
+  # Find the PR associated with this push, if there is one.
+  - uses: jwalton/gh-find-current-pr@master
+    id: findPr
+    with:
+      # Can be "open", "closed", or "all".  Defaults to "open".
+      state: open
+  # This will echo "Your PR is 7", or be skipped if there is no current PR.
+  - run: echo "Your PR is ${PR}"
+    if: success() && steps.findPr.outputs.number
+    env:
+      PR: ${{ steps.findPr.outputs.pr }}
 ```

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ By default, `gh-find-current-pr` will only return open PRs.  You can pass in a
 
 ```yaml
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       # Find the PR associated with this push, if there is one.
-      - uses: jwalton/gh-find-current-pr@v1
+      - uses: jwalton/gh-find-current-pr@main
         id: findPr
         with:
           # Can be "open", "closed", or "all".  Defaults to "open".

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ outputs:
   body:
     description: The PR's body if the PR was found
 runs:
-  using: node16
+  using: node20
   main: 'dist/index.js'
 branding:
   icon: git-pull-request

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,6 +537,41 @@
                 "@octokit/openapi-types": "^12.11.0"
             }
         },
+        "node_modules/@pnpm/config.env-replace": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/@pnpm/network.ca-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "4.2.10"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/@pnpm/npm-conf": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+            "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+            "dev": true,
+            "dependencies": {
+                "@pnpm/config.env-replace": "^1.1.0",
+                "@pnpm/network.ca-file": "^1.0.1",
+                "config-chain": "^1.1.11"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@semantic-release/commit-analyzer": {
             "version": "9.0.2",
             "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
@@ -640,22 +675,22 @@
             }
         },
         "node_modules/@semantic-release/npm": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
-            "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
+            "integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
             "dev": true,
             "dependencies": {
                 "@semantic-release/error": "^3.0.0",
                 "aggregate-error": "^3.0.0",
                 "execa": "^5.0.0",
-                "fs-extra": "^10.0.0",
+                "fs-extra": "^11.0.0",
                 "lodash": "^4.17.15",
                 "nerf-dart": "^1.0.0",
                 "normalize-url": "^6.0.0",
                 "npm": "^8.3.0",
                 "rc": "^1.2.8",
                 "read-pkg": "^5.0.0",
-                "registry-auth-token": "^4.0.0",
+                "registry-auth-token": "^5.0.0",
                 "semver": "^7.1.2",
                 "tempy": "^1.0.0"
             },
@@ -664,6 +699,20 @@
             },
             "peerDependencies": {
                 "semantic-release": ">=19.0.0"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
             }
         },
         "node_modules/@semantic-release/release-notes-generator": {
@@ -1292,6 +1341,16 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
         },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
         "node_modules/conventional-changelog-angular": {
             "version": "5.0.13",
             "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
@@ -1329,9 +1388,9 @@
             }
         },
         "node_modules/conventional-changelog-writer/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -3138,9 +3197,9 @@
             }
         },
         "node_modules/npm": {
-            "version": "8.19.2",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.2.tgz",
-            "integrity": "sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==",
+            "version": "8.19.4",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+            "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -3149,7 +3208,6 @@
                 "@npmcli/fs",
                 "@npmcli/map-workspaces",
                 "@npmcli/package-json",
-                "@npmcli/promise-spawn",
                 "@npmcli/run-script",
                 "abbrev",
                 "archy",
@@ -3220,13 +3278,12 @@
             "dev": true,
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^5.6.2",
+                "@npmcli/arborist": "^5.6.3",
                 "@npmcli/ci-detect": "^2.0.0",
                 "@npmcli/config": "^4.2.1",
                 "@npmcli/fs": "^2.1.0",
                 "@npmcli/map-workspaces": "^2.0.3",
                 "@npmcli/package-json": "^2.0.0",
-                "@npmcli/promise-spawn": "*",
                 "@npmcli/run-script": "^4.2.1",
                 "abbrev": "~1.1.1",
                 "archy": "~1.0.0",
@@ -3237,18 +3294,18 @@
                 "cli-table3": "^0.6.2",
                 "columnify": "^1.6.0",
                 "fastest-levenshtein": "^1.0.12",
-                "fs-minipass": "*",
+                "fs-minipass": "^2.1.0",
                 "glob": "^8.0.1",
                 "graceful-fs": "^4.2.10",
-                "hosted-git-info": "^5.1.0",
+                "hosted-git-info": "^5.2.1",
                 "ini": "^3.0.1",
                 "init-package-json": "^3.0.2",
                 "is-cidr": "^4.0.2",
                 "json-parse-even-better-errors": "^2.3.1",
                 "libnpmaccess": "^6.0.4",
                 "libnpmdiff": "^4.0.5",
-                "libnpmexec": "^4.0.13",
-                "libnpmfund": "^3.0.4",
+                "libnpmexec": "^4.0.14",
+                "libnpmfund": "^3.0.5",
                 "libnpmhook": "^8.0.4",
                 "libnpmorg": "^4.0.4",
                 "libnpmpack": "^4.1.3",
@@ -3257,7 +3314,7 @@
                 "libnpmteam": "^4.0.4",
                 "libnpmversion": "^3.0.7",
                 "make-fetch-happen": "^10.2.0",
-                "minimatch": "*",
+                "minimatch": "^5.1.0",
                 "minipass": "^3.1.6",
                 "minipass-pipeline": "^1.2.4",
                 "mkdirp": "^1.0.4",
@@ -3299,7 +3356,7 @@
                 "npx": "bin/npx-cli.js"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/npm-run-path": {
@@ -3337,7 +3394,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "5.6.2",
+            "version": "5.6.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -3355,6 +3412,7 @@
                 "bin-links": "^3.0.3",
                 "cacache": "^16.1.3",
                 "common-ancestor-path": "^1.0.1",
+                "hosted-git-info": "^5.2.1",
                 "json-parse-even-better-errors": "^2.3.1",
                 "json-stringify-nice": "^1.1.4",
                 "minimatch": "^5.1.0",
@@ -4166,7 +4224,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/hosted-git-info": {
-            "version": "5.1.0",
+            "version": "5.2.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -4178,7 +4236,7 @@
             }
         },
         "node_modules/npm/node_modules/http-cache-semantics": {
-            "version": "4.1.0",
+            "version": "4.1.1",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause"
@@ -4442,12 +4500,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "4.0.13",
+            "version": "4.0.14",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^5.6.2",
+                "@npmcli/arborist": "^5.6.3",
                 "@npmcli/ci-detect": "^2.0.0",
                 "@npmcli/fs": "^2.1.1",
                 "@npmcli/run-script": "^4.2.0",
@@ -4467,12 +4525,12 @@
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "3.0.4",
+            "version": "3.0.5",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^5.6.2"
+                "@npmcli/arborist": "^5.6.3"
             },
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -6062,6 +6120,12 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true
+        },
         "node_modules/punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -6246,9 +6310,9 @@
             }
         },
         "node_modules/read-pkg/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver"
@@ -6313,15 +6377,15 @@
             }
         },
         "node_modules/registry-auth-token": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
-            "integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+            "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
             "dev": true,
             "dependencies": {
-                "rc": "1.2.8"
+                "@pnpm/npm-conf": "^2.1.0"
             },
             "engines": {
-                "node": ">=6.0.0"
+                "node": ">=14"
             }
         },
         "node_modules/require-directory": {
@@ -6503,9 +6567,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -6530,9 +6594,9 @@
             }
         },
         "node_modules/semver-diff/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -7170,9 +7234,9 @@
             }
         },
         "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -7685,6 +7749,32 @@
                 "@octokit/openapi-types": "^12.11.0"
             }
         },
+        "@pnpm/config.env-replace": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+            "dev": true
+        },
+        "@pnpm/network.ca-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.2.10"
+            }
+        },
+        "@pnpm/npm-conf": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+            "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+            "dev": true,
+            "requires": {
+                "@pnpm/config.env-replace": "^1.1.0",
+                "@pnpm/network.ca-file": "^1.0.1",
+                "config-chain": "^1.1.11"
+            }
+        },
         "@semantic-release/commit-analyzer": {
             "version": "9.0.2",
             "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
@@ -7761,24 +7851,37 @@
             }
         },
         "@semantic-release/npm": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
-            "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
+            "integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
             "dev": true,
             "requires": {
                 "@semantic-release/error": "^3.0.0",
                 "aggregate-error": "^3.0.0",
                 "execa": "^5.0.0",
-                "fs-extra": "^10.0.0",
+                "fs-extra": "^11.0.0",
                 "lodash": "^4.17.15",
                 "nerf-dart": "^1.0.0",
                 "normalize-url": "^6.0.0",
                 "npm": "^8.3.0",
                 "rc": "^1.2.8",
                 "read-pkg": "^5.0.0",
-                "registry-auth-token": "^4.0.0",
+                "registry-auth-token": "^5.0.0",
                 "semver": "^7.1.2",
                 "tempy": "^1.0.0"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "11.2.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+                    "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                }
             }
         },
         "@semantic-release/release-notes-generator": {
@@ -8207,6 +8310,16 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true
         },
+        "config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "requires": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
         "conventional-changelog-angular": {
             "version": "5.0.13",
             "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
@@ -8235,9 +8348,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "dev": true
                 }
             }
@@ -9580,19 +9693,18 @@
             "dev": true
         },
         "npm": {
-            "version": "8.19.2",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.2.tgz",
-            "integrity": "sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==",
+            "version": "8.19.4",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+            "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
             "dev": true,
             "requires": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^5.6.2",
+                "@npmcli/arborist": "^5.6.3",
                 "@npmcli/ci-detect": "^2.0.0",
                 "@npmcli/config": "^4.2.1",
                 "@npmcli/fs": "^2.1.0",
                 "@npmcli/map-workspaces": "^2.0.3",
                 "@npmcli/package-json": "^2.0.0",
-                "@npmcli/promise-spawn": "*",
                 "@npmcli/run-script": "^4.2.1",
                 "abbrev": "~1.1.1",
                 "archy": "~1.0.0",
@@ -9603,18 +9715,18 @@
                 "cli-table3": "^0.6.2",
                 "columnify": "^1.6.0",
                 "fastest-levenshtein": "^1.0.12",
-                "fs-minipass": "*",
+                "fs-minipass": "^2.1.0",
                 "glob": "^8.0.1",
                 "graceful-fs": "^4.2.10",
-                "hosted-git-info": "^5.1.0",
+                "hosted-git-info": "^5.2.1",
                 "ini": "^3.0.1",
                 "init-package-json": "^3.0.2",
                 "is-cidr": "^4.0.2",
                 "json-parse-even-better-errors": "^2.3.1",
                 "libnpmaccess": "^6.0.4",
                 "libnpmdiff": "^4.0.5",
-                "libnpmexec": "^4.0.13",
-                "libnpmfund": "^3.0.4",
+                "libnpmexec": "^4.0.14",
+                "libnpmfund": "^3.0.5",
                 "libnpmhook": "^8.0.4",
                 "libnpmorg": "^4.0.4",
                 "libnpmpack": "^4.1.3",
@@ -9623,7 +9735,7 @@
                 "libnpmteam": "^4.0.4",
                 "libnpmversion": "^3.0.7",
                 "make-fetch-happen": "^10.2.0",
-                "minimatch": "*",
+                "minimatch": "^5.1.0",
                 "minipass": "^3.1.6",
                 "minipass-pipeline": "^1.2.4",
                 "mkdirp": "^1.0.4",
@@ -9678,7 +9790,7 @@
                     "dev": true
                 },
                 "@npmcli/arborist": {
-                    "version": "5.6.2",
+                    "version": "5.6.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -9695,6 +9807,7 @@
                         "bin-links": "^3.0.3",
                         "cacache": "^16.1.3",
                         "common-ancestor-path": "^1.0.1",
+                        "hosted-git-info": "^5.2.1",
                         "json-parse-even-better-errors": "^2.3.1",
                         "json-stringify-nice": "^1.1.4",
                         "minimatch": "^5.1.0",
@@ -10271,7 +10384,7 @@
                     "dev": true
                 },
                 "hosted-git-info": {
-                    "version": "5.1.0",
+                    "version": "5.2.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -10279,7 +10392,7 @@
                     }
                 },
                 "http-cache-semantics": {
-                    "version": "4.1.0",
+                    "version": "4.1.1",
                     "bundled": true,
                     "dev": true
                 },
@@ -10468,11 +10581,11 @@
                     }
                 },
                 "libnpmexec": {
-                    "version": "4.0.13",
+                    "version": "4.0.14",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "@npmcli/arborist": "^5.6.2",
+                        "@npmcli/arborist": "^5.6.3",
                         "@npmcli/ci-detect": "^2.0.0",
                         "@npmcli/fs": "^2.1.1",
                         "@npmcli/run-script": "^4.2.0",
@@ -10489,11 +10602,11 @@
                     }
                 },
                 "libnpmfund": {
-                    "version": "3.0.4",
+                    "version": "3.0.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "@npmcli/arborist": "^5.6.2"
+                        "@npmcli/arborist": "^5.6.3"
                     }
                 },
                 "libnpmhook": {
@@ -11617,6 +11730,12 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
+        "proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true
+        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -11692,9 +11811,9 @@
                     }
                 },
                 "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "version": "5.7.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+                    "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
                     "dev": true
                 },
                 "type-fest": {
@@ -11802,12 +11921,12 @@
             "dev": true
         },
         "registry-auth-token": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
-            "integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+            "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
             "dev": true,
             "requires": {
-                "rc": "1.2.8"
+                "@pnpm/npm-conf": "^2.1.0"
             }
         },
         "require-directory": {
@@ -11940,9 +12059,9 @@
             }
         },
         "semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "requires": {
                 "lru-cache": "^6.0.0"
@@ -11958,9 +12077,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
                     "dev": true
                 }
             }
@@ -12457,9 +12576,9 @@
             }
         },
         "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true
         },
         "wordwrap": {


### PR DESCRIPTION
Fixes #115 

---

This relates to warning messages listed under Github Action workflow runs, such as:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: jwalton/gh-find-current-pr@v1. 

For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
