### PR TITLE
Update action to use Node.js 22

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ outputs:
   body:
     description: The PR's body if the PR was found
 runs:
-  using: node20
+  using: node22
   main: 'dist/index.js'
 branding:
   icon: git-pull-request


### PR DESCRIPTION
see https://github.com/open-abap/open-abap-core/actions/runs/23062677010

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: jwalton/gh-find-current-pr@v1